### PR TITLE
Read BG targets in using mmol when server is in mmol mode (#5291)

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,10 +241,10 @@ To learn more about the Nightscout API, visit https://YOUR-SITE.com/api-docs/ or
   These alarm setting affect all delivery methods (browser, Pushover, IFTTT, etc.). Values and settings entered here will be the defaults for new browser views, but will be overridden if different choices are made in the settings UI.
 
   * `ALARM_TYPES` (`simple` if any `BG_`* ENV's are set, otherwise `predict`) - currently 2 alarm types are supported, and can be used independently or combined.  The `simple` alarm type only compares the current BG to `BG_` thresholds above, the `predict` alarm type uses highly tuned formula that forecasts where the BG is going based on it's trend.  `predict` **DOES NOT** currently use any of the `BG_`* ENV's
-  * `BG_HIGH` (`260`) - must be set using mg/dl units; the high BG outside the target range that is considered urgent
-  * `BG_TARGET_TOP` (`180`) - must be set using mg/dl units; the top of the target range, also used to draw the line on the chart
-  * `BG_TARGET_BOTTOM` (`80`) - must be set using mg/dl units; the bottom of the target range, also used to draw the line on the chart
-  * `BG_LOW` (`55`) - must be set using mg/dl units; the low BG outside the target range that is considered urgent
+  * `BG_HIGH` (`260`) - the high BG outside the target range that is considered urgent (interprets units based on DISPLAY_UNITS setting)
+  * `BG_TARGET_TOP` (`180`) - the top of the target range, also used to draw the line on the chart (interprets units based on DISPLAY_UNITS setting)
+  * `BG_TARGET_BOTTOM` (`80`) - the bottom of the target range, also used to draw the line on the chart (interprets units based on DISPLAY_UNITS setting)
+  * `BG_LOW` (`55`) - the low BG outside the target range that is considered urgent (interprets units based on DISPLAY_UNITS setting)
   * `ALARM_URGENT_HIGH` (`on`) - possible values `on` or `off`
   * `ALARM_URGENT_HIGH_MINS` (`30 60 90 120`) - Number of minutes to snooze urgent high alarms, space separated for options in browser, first used for pushover
   * `ALARM_HIGH` (`on`) - possible values `on` or `off`

--- a/app.json
+++ b/app.json
@@ -53,22 +53,22 @@
       "required": true
     },
     "BG_HIGH": {
-      "description": "Urgent High BG threshold, triggers the ALARM_URGENT_HIGH alarm. Must be set in mg/dL, even if you use mmol/L (multiply a mmol/L value by 18 to change it to mg/dl).",
+      "description": "Urgent High BG threshold, triggers the ALARM_URGENT_HIGH alarm. Set in mg/dL or mmol/L, as set in DISPLAY_UNITS variable.",
       "value": "260",
       "required": false
     },
     "BG_LOW": {
-      "description": "Urgent Low BG threshold, triggers the ALARM_URGENT_LOW alarm. Must be set in mg/dL, even if you use mmol/L (multiply a mmol/L value by 18 to change it to mg/dl).",
+      "description": "Urgent Low BG threshold, triggers the ALARM_URGENT_LOW alarm. Set in mg/dL or mmol/L, as set in DISPLAY_UNITS variable.",
       "value": "55",
       "required": false
     },
     "BG_TARGET_BOTTOM": {
-      "description": "Low BG threshold, triggers the ALARM_LOW alarm. Must be set in mg/dL, even if you use mmol/L (multiply a mmol/L value by 18 to change it to mg/dl).",
+      "description": "Low BG threshold, triggers the ALARM_LOW alarm. Set in mg/dL or mmol/L, as set in DISPLAY_UNITS variable.",
       "value": "80",
       "required": false
     },
     "BG_TARGET_TOP": {
-      "description": "High BG threshold, triggers the ALARM_HIGH alarm. Must be set in mg/dL, even if you use mmol/L (multiply a mmol/L value by 18 to change it to mg/dl).",
+      "description": "High BG threshold, triggers the ALARM_HIGH alarm. Set in mg/dL or mmol/L, as set in DISPLAY_UNITS variable.",
       "value": "180",
       "required": false
     },

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -2,11 +2,12 @@
 
 var _ = require('lodash');
 var levels = require('./levels');
+var constants = require('./constants.json');
 
 function init () {
 
   var settings = {
-    units: 'mg/dL'
+    units: 'mg/dl'
     , timeFormat: 12
     , nightMode: false
     , editMode: true
@@ -73,6 +74,10 @@ function init () {
     , deNormalizeDates: mapTruthy
     , showClockDelta: mapTruthy
     , showClockLastTime: mapTruthy
+    , bgHigh: mapNumber
+    , bgLow: mapNumber
+    , bgTargetTop: mapNumber
+    , bgTargetBottom: mapNumber
   };
 
   function mapNumberArray (value) {
@@ -93,6 +98,11 @@ function init () {
   function mapNumber (value) {
     if (!value) {
       return value;
+    }
+
+    if (typeof value === 'string' && isNaN(value)) {
+      const decommaed = value.replace(',','.');
+      if (!isNaN(decommaed)) { value = decommaed; }
     }
 
     if (isNaN(value)) {
@@ -209,6 +219,14 @@ function init () {
     thresholds.bgTargetTop = Number(thresholds.bgTargetTop);
     thresholds.bgTargetBottom = Number(thresholds.bgTargetBottom);
     thresholds.bgLow = Number(thresholds.bgLow);
+
+    // Do not convert for old installs that have these set in mg/dl
+    if (settings.units.toLowerCase().includes('mmol') && thresholds.bgHigh < 50) {
+      thresholds.bgHigh = Math.round(thresholds.bgHigh * constants.MMOL_TO_MGDL);
+      thresholds.bgTargetTop = Math.round(thresholds.bgTargetTop * constants.MMOL_TO_MGDL);
+      thresholds.bgTargetBottom = Math.round(thresholds.bgTargetBottom * constants.MMOL_TO_MGDL);
+      thresholds.bgLow = Math.round(thresholds.bgLow * constants.MMOL_TO_MGDL);
+    }
 
     verifyThresholds();
     adjustShownPlugins();


### PR DESCRIPTION
* Read BG targets in using mmol when server is in mmol mode

* Change the Heroku template to match the new logic

* Deal with mmol targets being set using commas