### PR TITLE
Added period of days into headline of glucose distribution and percen…

### DIFF
--- a/lib/report_plugins/glucosedistribution.js
+++ b/lib/report_plugins/glucosedistribution.js
@@ -19,9 +19,9 @@ glucosedistribution.html = function html (client) {
   var ret =
     '<h2>' +
     translate('Glucose distribution') +
-    '  (' +
-    '  <span id="glucosedistribution-days"></span>' +
-    '  )' +
+    ' (' +
+    '<span id="glucosedistribution-days"></span>' +
+    ')' +
     '  </h2>' +
     '<table><tr>' +
     '<td rowspan="2" style="valign:middle;"><div id="glucosedistribution-overviewchart"></div></td>' +
@@ -122,7 +122,11 @@ glucosedistribution.report = function report_glucosedistribution (datastorage, s
   var data = datastorage.allstatsrecords;
   var days = datastorage.alldays;
 
-  $('#glucosedistribution-days').text(days + ' ' + translate('days total'));
+  var reportPlugins = Nightscout.report_plugins;
+  var firstDay = reportPlugins.utils.localeDate(sorteddaystoshow[sorteddaystoshow.length - 1]);
+  var lastDay = reportPlugins.utils.localeDate(sorteddaystoshow[0]);
+
+  $('#glucosedistribution-days').text(days + ' ' + translate('days total') + ', ' + firstDay + ' - ' + lastDay);
 
   for (var i = 0; i < 24; i++) {
     $('#glucosedistribution-' + i).unbind('click').click(onClick);

--- a/lib/report_plugins/percentile.js
+++ b/lib/report_plugins/percentile.js
@@ -15,11 +15,17 @@ module.exports = init;
 percentile.html = function html(client) {
   var translate = client.translate;
   var ret =
-      '<h2>' + translate('Glucose Percentile report') + '</h2>'
-    + '<div style="height:500px;">'
-    + '  <div class="chart" id="percentile-chart"></div>'
-    + '</div>'
-    ;
+  '<h2>'
+  + translate('Glucose Percentile report')
+  + ' ('
+  + '<span id="percentile-days"></span>'
+  + ')'
+  + '</h2>'
+  + '<div style="height:500px;">'
+  + '  <div class="chart" id="percentile-chart"></div>'
+  + '</div>'
+  ;
+
   return ret;
 };
 
@@ -36,16 +42,23 @@ percentile.report = function report_percentile(datastorage, sorteddaystoshow, op
   var translate = client.translate;
   var ss = require('simple-statistics');
 
-  var minutewindow = 30; //minute-window should be a divisor of 60 
-  
+  var minutewindow = 30; //minute-window should be a divisor of 60
+
   var data = datastorage.allstatsrecords;
-  
+
   var bins = [];
   var filterFunc = function withinWindow(record) {
     var recdate = new Date(record.displayTime);
     return recdate.getHours() === hour && recdate.getMinutes() >= minute && recdate.getMinutes() < minute + minutewindow;
   };
-  
+
+  var reportPlugins = Nightscout.report_plugins;
+  var firstDay = reportPlugins.utils.localeDate(sorteddaystoshow[sorteddaystoshow.length - 1]);
+  var lastDay = reportPlugins.utils.localeDate(sorteddaystoshow[0]);
+  var countDays = sorteddaystoshow.length;
+
+  $('#percentile-days').text(countDays + ' ' + translate('days total') + ', ' + firstDay + ' - ' + lastDay);
+
   for (var hour = 0; hour < 24; hour++) {
     for (var minute = 0; minute < 60; minute = minute + minutewindow) {
       var date = new Date();


### PR DESCRIPTION
…… (#5428)

* Added period of days into headline of glucose distribution and percentil chart report

I make screencopies of the glucose distribution and percential chart report for my diabtes consultant and had to manually add the period of days to the report everytime because it was not shown in the report itself.
I added the period of days this with a small number of lines of code and think this is helpful for other too.

* removed comments as requested

removed comments as requested

* Camelcase for new variables reportPlugins, firstDay, lastDay, countDays

* forget to save the change of reportPlugins in percentile.js