### PR TITLE
Trying to fix random fail of APIv3 tests (#5519)

### DIFF
--- a/tests/api.alexa.test.js
+++ b/tests/api.alexa.test.js
@@ -7,6 +7,7 @@ const bodyParser = require('body-parser');
 require('should');
 
 describe('Alexa REST api', function ( ) {
+  this.timeout(10000);
   const apiRoot = require('../lib/api/root');
   const api = require('../lib/api/');
   before(function (done) {

--- a/tests/api3.create.test.js
+++ b/tests/api3.create.test.js
@@ -16,7 +16,7 @@ describe('API3 CREATE', function() {
   self.validDoc = {
     date: (new Date()).getTime(),
     app: testConst.TEST_APP,
-    device: testConst.TEST_DEVICE,
+    device: testConst.TEST_DEVICE + ' API3 CREATE',
     eventType: 'Correction Bolus',
     insulin: 0.3
   };

--- a/tests/api3.generic.workflow.test.js
+++ b/tests/api3.generic.workflow.test.js
@@ -19,7 +19,7 @@ describe('Generic REST API3', function() {
     insulin: 1,
     date: (new Date()).getTime(),
     app: testConst.TEST_APP,
-    device: testConst.TEST_DEVICE
+    device: testConst.TEST_DEVICE + ' Generic REST API3'
   };
   self.identifier = opTools.calculateIdentifier(self.docOriginal);
   self.docOriginal.identifier = self.identifier;

--- a/tests/api3.patch.test.js
+++ b/tests/api3.patch.test.js
@@ -15,7 +15,7 @@ describe('API3 PATCH', function() {
     date: (new Date()).getTime(),
     utcOffset: -180,
     app: testConst.TEST_APP,
-    device: testConst.TEST_DEVICE,
+    device: testConst.TEST_DEVICE + ' API3 PATCH',
     eventType: 'Correction Bolus',
     insulin: 0.3
   };

--- a/tests/api3.read.test.js
+++ b/tests/api3.read.test.js
@@ -15,7 +15,7 @@ describe('API3 READ', function() {
   self.validDoc = {
     date: (new Date()).getTime(),
     app: testConst.TEST_APP,
-    device: testConst.TEST_DEVICE,
+    device: testConst.TEST_DEVICE + ' API3 READ',
     uploaderBattery: 58
   };
   self.validDoc.identifier = opTools.calculateIdentifier(self.validDoc);

--- a/tests/api3.update.test.js
+++ b/tests/api3.update.test.js
@@ -17,6 +17,7 @@ describe('API3 UPDATE', function() {
     date: (new Date()).getTime(),
     utcOffset: -180,
     app: testConst.TEST_APP,
+    device: testConst.TEST_DEVICE + ' API3 UPDATE',
     eventType: 'Correction Bolus',
     insulin: 0.3
   };


### PR DESCRIPTION
* APIv3: isolating documents from tests (not allowing clashes of calculated identifiers)

* removing unused async keyword